### PR TITLE
allow changing the listening port + dev environment fixes

### DIFF
--- a/docs/technical/dev-environment.md
+++ b/docs/technical/dev-environment.md
@@ -3,6 +3,10 @@ The best way to try euphonium is to flash a prebuilt version. However, if you wa
 
 ## Setup
 
+### Checkout
+
+When checking out the repository, use `--recursive` to retrieve all submodules. Alternately, after checkout use `git submodule update --init --recursive` to perform the same task.
+
 ### Setting up web UI bundler
 
 First, a required step is to setup all of the dependencies required to build the web UI.
@@ -10,8 +14,9 @@ First, a required step is to setup all of the dependencies required to build the
 #### Dependencies
 - `nodejs` in version of at least 14
 - `yarn`
+- `npm`
 
-Installation of both is platform specific, but mostly just comes down to installing them through a package manager.
+Installation of these are platform specific, but mostly just comes down to installing them through a package manager.
 
 ### Setting up dependencies
 
@@ -48,7 +53,8 @@ For a desktop run, please run the following commands
     ```
 
 
-This will output a binary `euphoniumcli` which can be later executed to run the platform. The web-ui will be available on port `80`.
+This will output a binary `euphoniumcli` which can be later executed to run the platform. The web-ui will be available on port `80` by default.
+If you have trouble using port 80 (on Linux for example), use `cmake .. -D HTTP_SERVER_PORT=8080` to change the web-ui port.
 
 ### Building and installing the project - ESP32
 

--- a/euphonium/CMakeLists.txt
+++ b/euphonium/CMakeLists.txt
@@ -22,6 +22,11 @@ else()
     add_definitions(-Wno-sequence-point)
 endif()
 
+if (NOT DEFINED HTTP_SERVER_PORT)
+  set(HTTP_SERVER_PORT 80)
+endif()
+add_definitions( -DHTTP_SERVER_PORT=${HTTP_SERVER_PORT} )
+
 if(UNIX AND NOT APPLE)
     set(EXTRA_REQ_LIBS ${EXTRA_REQ_LIBS})
 endif()

--- a/euphonium/src/plugins/http/HTTPModule.cpp
+++ b/euphonium/src/plugins/http/HTTPModule.cpp
@@ -24,7 +24,7 @@ void listFiles(const std::string &path,
 
 HTTPModule::HTTPModule() : bell::Task("http", 1024 * 6, 0, 0, false) {
     name = "http";
-    mainServer = std::make_shared<bell::HTTPServer>(80);
+    mainServer = std::make_shared<bell::HTTPServer>(HTTP_SERVER_PORT);
 }
 
 void HTTPModule::loadScript(std::shared_ptr<ScriptLoader> loader) {

--- a/targets/cli/cmake/build_web.sh
+++ b/targets/cli/cmake/build_web.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 cd ../../web
+npm install
 npm run build
 rm -rf ../targets/cli/build/web
 cp -R dist ../targets/cli/build/web


### PR DESCRIPTION
Add a cmake variable to set the listening port, so on platforms where listening on port 80 is not ideal, it can easily be set at build time. Updated documentation to mention this and a few other caveats hit while setting up a dev environment.