### PR TITLE
fix doc 

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,4 +13,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CONFIG_FILE: mkdocs.yml
-          EXTRA_PACKAGES: build-base
+          EXTRA_PACKAGES: build-base linux-headers

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 Highly extensible streaming audio player targeting low cost MCUs like ESP32. Currently under very rapid development, documentation coming soon.
 
-Current state: Feature freeze until end of January.
-
 ## Documentation
 You can access the project's documentation [here](https://feelfreelinux.github.io/euphonium/).
 


### PR DESCRIPTION
and remove feature-freeze

it looks like there is no pip wheel for latest grpcio on alpine linux, so pip wants to build grpcio localy and needs the linux header files.